### PR TITLE
Bump check-md to 1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "ulivz<chl814@foxmail.com>",
   "license": "MIT",
   "dependencies": {
-    "check-md": "1.0.0"
+    "check-md": "1.0.1"
   },
   "devDependencies": {
     "xo": "0.23.0",


### PR DESCRIPTION
I stumbled upon this while trying to figure out why `ignoreFootnotes: true` as option didn't do anything.